### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.git
+.vscode
+*.log
+tests


### PR DESCRIPTION
## Summary
- reduce Docker build context by adding `.dockerignore`

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68794839eb7c832db618080e03c0926c