### PR TITLE
Add MCP docker service

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ npm install
 npm run build
 ```
 
-3. Start the Planka containers:
+3. Start the Docker containers (Planka, PostgreSQL, and the MCP server):
 ```bash
+docker compose up
+# or use the convenience script
 npm run up
 ```
 
@@ -135,7 +137,7 @@ For more details on these strategies, see the [Capabilities and Strategies](http
 
 - `npm run build`: Build the TypeScript code
 - `npm run build-docker`: Build the TypeScript code and create a Docker image
-- `npm run up`: Start the Planka containers (kanban and postgres)
+- `npm run up`: Start all containers (Planka, Postgres, and the MCP server)
 - `npm run down`: Stop all containers
 - `npm run restart`: Restart the Planka containers
 - `npm run start-node`: Start the MCP server directly with Node (for testing outside of Cursor)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,21 @@ services:
       - kanban-project-background-images:/app/public/project-background-images
       - kanban-attachments:/app/private/attachments
 
+  mcp-kanban:
+    build: .
+    container_name: mcp-kanban
+    restart: unless-stopped
+    ports:
+      - "${MCP_KANBAN_PORT}:3008"
+    depends_on:
+      - kanban
+    environment:
+      - PLANKA_BASE_URL=http://kanban:1337
+      - PLANKA_AGENT_EMAIL=${PLANKA_AGENT_EMAIL}
+      - PLANKA_AGENT_PASSWORD=${PLANKA_AGENT_PASSWORD}
+    volumes:
+      - mcp-kanban-attachments:/app/attachments
+
   postgres:
     image: postgres:15-alpine
     container_name: kanban-postgres
@@ -61,3 +76,4 @@ volumes:
   kanban-user-avatars:
   kanban-project-background-images:
   kanban-attachments:
+  mcp-kanban-attachments:


### PR DESCRIPTION
## Summary
- start MCP server via new `mcp-kanban` service
- persist attachments volume for MCP server
- document that `docker compose up` starts Planka, Postgres and the MCP server

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68794b2acdd4832d8222512034717084